### PR TITLE
add jast-tech as a company

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,12 @@
 
   - Industry: JiggyTech
 
+* Company: [JastTech](https://www.jast-tech.com/)
+
+  - Founder: [@CoucoSeth](https://twitter.com/JastTech)
+
+  - Industry: Mobile and Web apps service provider
+
 ## <a name="K"> </a>K
 
 * Company: [Kudabank](https://kudabank.com/)


### PR DESCRIPTION
This is to add Jast tech ltd, a fully registered Ugandan based company that provides mobile and web app development as a service.